### PR TITLE
Makefile: compatibility with OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ $(TARG).1: $(TARG)
 	./$(TARG) --create-manpage > $@
 
 install: $(TARG) $(TARG).1
-	install -D -d -m755 $(bindir)
+	mkdir -p $(bindir)
+	mkdir -p $(mandir)
 	install -m755 $(TARG) $(bindir)
-	install -D -d -m755 $(man1dir)
 	install -m644 $(TARG).1 $(man1dir)
 
 clean:


### PR DESCRIPTION
`-D` is an illegal option for `install` on OSX, but it (and `-d`) can be replaced with `mkdir -p`