### PR TITLE
Issue#27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,10 @@ $(TARG): $(GOFILES)
 $(TARG).1: $(TARG)
 	./$(TARG) --help-man > $@
 
-copy: 
+install: 
 	install -m755 $(TARG) $(bindir)/$(TARG)
 	install -d -m644 $(man1dir)
 	install -m644 $(TARG).1 $(man1dir)/$(TARG).1
-
-install: copy clean
-
-clean:
-	rm -f $(TARG) $(TARG).1
 
 uninstall:
 	rm $(bindir)/$(TARG)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(TARG).1: $(TARG)
 
 install: $(TARG) $(TARG).1
 	install -m755 $(TARG) $(bindir)/$(TARG)
-	install -m644 $(TARG).1 $(man1dir)/$(TARG).1
+	install -D -m644 $(TARG).1 $(man1dir)/$(TARG).1
 
 clean:
 	rm -f $(TARG) $(TARG).1

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ $(TARG).1: $(TARG)
 
 install: $(TARG) $(TARG).1
 	install -m755 $(TARG) $(bindir)/$(TARG)
-	install -D -m644 $(TARG).1 $(man1dir)/$(TARG).1
+	install -d -m644 $(man1dir)
+	install -m644 $(TARG).1 $(man1dir)/$(TARG).1
 
 clean:
 	rm -f $(TARG) $(TARG).1

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,12 @@ $(TARG): $(GOFILES)
 $(TARG).1: $(TARG)
 	./$(TARG) --help-man > $@
 
-install: $(TARG) $(TARG).1
+copy: 
 	install -m755 $(TARG) $(bindir)/$(TARG)
 	install -d -m644 $(man1dir)
 	install -m644 $(TARG).1 $(man1dir)/$(TARG).1
+
+install: copy clean
 
 clean:
 	rm -f $(TARG) $(TARG).1

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ install: copy clean
 
 clean:
 	rm -f $(TARG) $(TARG).1
+
+uninstall:
+	rm $(bindir)/$(TARG)
+	rm $(man1dir)/$(TARG).1

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,8 @@ Once you have Go installed and your ``GOPATH`` set, do the following::
   $ go get gopkg.in/alecthomas/kingpin.v2
   $ git clone git://github.com/alecthomas/devtodo2.git
   $ cd devtodo2
-  $ make install
+  $ make
+  $ [sudo] make install
 
 This will install to ``/usr/local`` by default, but that can be overridden by
 passing ``prefix=<dir>`` to ``make``. The installation directories can be

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,11 @@ and ``$(mandir)/man1``, respectively.
 But the binary will be named ``devtodo2`` and the man page will not be
 installed.
 
+Uninstalling
+----------
+  $ cd devtodo2
+  $ [sudo] make uninstall
+
 Examples
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ installed.
 
 Uninstalling
 ----------
+If you want to uninstall, do the following::
+
   $ cd devtodo2
   $ [sudo] make uninstall
 


### PR DESCRIPTION
`sudo make install
`
When executing: 
`go build -o todo2 todo.go view.go consoleview.go legacyio.go jsonio.go main.go importer.go`
would throw:

`make: go: Command not found`

My changes: 

- Added a `make` step before `make install ` that builds the man page and go dist.
- Added a copy target to the make file, and modified the install target to call copy, and then clean.
- Added better clarification in the README that  `make install ` has a optional `sudo`.
- Added a make uninstall target for Issue #14.
- Modified the README to contain a Uninstall section.  

